### PR TITLE
Shadows: keep snow out of the shadow map, wrap the torus seam

### DIFF
--- a/bin/game/main.rs
+++ b/bin/game/main.rs
@@ -485,7 +485,7 @@ impl Game {
         let submission = loader.finish();
         render.accept_submission(submission);
         render.wait_for_gpu();
-        render.set_shadow_extent(map_extent);
+        render.configure_map(map_extent, &terrain.config);
 
         // Camera clip-far has to cover the far side of the world: the
         // cylinder is bounded by its length along Z, the sphere and the
@@ -816,6 +816,7 @@ impl Game {
             model: Arc::new(model),
             transform,
             geometry_filter: None,
+            casts_shadow: true,
         };
 
         // Procedural wheel mesh, used for every physics wheel. The wheel
@@ -842,6 +843,7 @@ impl Game {
                     model: wheel_model.clone(),
                     transform: pose,
                     geometry_filter: None,
+                    casts_shadow: true,
                 })
             })
             .collect();

--- a/bin/game/snow.rs
+++ b/bin/game/snow.rs
@@ -146,6 +146,9 @@ impl Snow {
                     rotation: nalgebra::UnitQuaternion::identity(),
                 },
                 geometry_filter: None,
+                // See ModelInstance::casts_shadow — particle dots blow up
+                // into blotches under the PCF kernel.
+                casts_shadow: false,
             });
             // Stagger initial ages over [0, lifetime) so respawn moments are
             // uncorrelated from the very first tick — otherwise the first

--- a/bin/snapshot/main.rs
+++ b/bin/snapshot/main.rs
@@ -185,7 +185,7 @@ fn main() {
     let submission = loader.finish();
     render.accept_submission(submission);
     render.wait_for_gpu();
-    render.set_shadow_extent(map_extent);
+    render.configure_map(map_extent, &terrain.config);
 
     // ---- Render one frame ----
     let clip_far = match terrain.config.shape {

--- a/lib/content-packs/src/templates.rs
+++ b/lib/content-packs/src/templates.rs
@@ -46,6 +46,7 @@ impl ObjectTemplate {
         transform: nalgebra::Isometry3<f32>,
     ) -> Object {
         let model_instance = self.model.as_ref().map(|m| ModelInstance {
+            casts_shadow: true,
             model: m.clone(),
             transform,
             geometry_filter: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -139,4 +139,9 @@ pub struct ModelInstance {
     /// chassis instance can skip wheel geometries and per-wheel instances
     /// can render just the wheel mesh at the corresponding rigid-body pose.
     pub geometry_filter: Option<Vec<usize>>,
+    /// Whether this instance writes into the shadow map. Off for the debug
+    /// snow: a 0.1 m particle's dot blows up to a metre-wide blotch under
+    /// the PCF kernel, so a hundred of them read as dirt smeared across the
+    /// terrain rather than as shadows.
+    pub casts_shadow: bool,
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -640,11 +640,34 @@ impl Render {
         self.last_submission = Some(submission);
     }
 
-    /// Resize the cylindrical shadow texture to match the loaded heightmap.
-    /// Should be called once after the terrain PNG is loaded so a shadow texel
-    /// corresponds 1:1 to a heightmap texel.
-    pub fn set_shadow_extent(&mut self, extent: gpu::Extent) {
+    /// Configure the per-map render state: resize the shadow texture to
+    /// match the heightmap (a shadow texel corresponds 1:1 to a heightmap
+    /// texel), and pick the sampler wrap modes for the world shape — on the
+    /// torus the axial (v) direction wraps like the angular one, so shadows
+    /// and terrain colours stay continuous across the arc seam.
+    pub fn configure_map(&mut self, extent: gpu::Extent, config: &crate::MapConfig) {
         self.wait_for_gpu();
+        let v_mode = match config.shape {
+            WorldShape::Torus => gpu::AddressMode::Repeat,
+            WorldShape::Cylinder | WorldShape::Sphere => gpu::AddressMode::ClampToEdge,
+        };
+        for (sampler, name) in [
+            (&mut self.terrain_sampler, "terrain"),
+            (&mut self.shadow_sampler, "shadow"),
+        ] {
+            self.gpu_context.destroy_sampler(*sampler);
+            *sampler = self.gpu_context.create_sampler(gpu::SamplerDesc {
+                name,
+                address_modes: [
+                    gpu::AddressMode::Repeat,
+                    v_mode,
+                    gpu::AddressMode::ClampToEdge,
+                ],
+                mag_filter: gpu::FilterMode::Linear,
+                min_filter: gpu::FilterMode::Linear,
+                ..Default::default()
+            });
+        }
         self.shadow_texture.init_2d(
             &self.gpu_context,
             "shadow",
@@ -710,6 +733,9 @@ impl Render {
             if let mut pen = pass.with(&self.shadow_model_pipeline) {
                 pen.bind(0, &ShadowGlobalData { g_cyl: cyl_params });
                 for model_instance in models {
+                    if !model_instance.casts_shadow {
+                        continue;
+                    }
                     let base_transform = model_instance.transform.to_matrix();
                     for (gi, geometry) in model_instance.model.geometries.iter().enumerate() {
                         if let Some(filter) = model_instance.geometry_filter.as_ref() {


### PR DESCRIPTION
Investigated the shadow path across backends by visualising the shadow map region around the vehicle on Vulkan and WebGL2: the cast-shadow writes land at the same (u, v) with the same depths on both — placement, MIN-blend and sampling all agree since the upstream blade fixes. Two real defects surfaced instead:

* Snow particles were writing into the shadow map. A 0.1 m particle's single-texel dot inflates to a metre-wide blotch under the PCF kernel (four times worse on the web's downsampled shadow map), so a hundred of them read as dirt smeared over the terrain. ModelInstance grew a casts_shadow flag and the debug snow opts out.
* The shadow and terrain samplers clamped the axial (v) axis, but on the torus v wraps — shadows and colours broke across the arc seam. set_shadow_extent became configure_map, which also picks Repeat for v when the world is a torus.

Verified on Lavapipe and headless Chromium: contact shadow under the vehicle on both, no particle blotches, matching frames.


Claude-Session: https://claude.ai/code/session_018yNc1UQL7MgZmUMyd56utb